### PR TITLE
Implement imageRootDirMounted and aufsDiffPaths (AUFS support)

### DIFF
--- a/lib/docker-toolbelt.coffee
+++ b/lib/docker-toolbelt.coffee
@@ -7,6 +7,7 @@ tar = require 'tar-stream'
 es = require 'event-stream'
 fs = Promise.promisifyAll(require('fs'))
 path = require 'path'
+execAsync = Promise.promisify(require('child_process').exec)
 
 Promise.promisifyAll(Docker.prototype)
 # Hack dockerode to promisify internal classes' prototypes
@@ -28,6 +29,12 @@ digest = (data) ->
 createChainId = (diffIds) ->
 	return createChainIdFromParent('', diffIds)
 
+getAllChainIds = (diffIds) ->
+	chainIds = [ diffIds[0] ]
+	for i in [0...diffIds.length - 1]
+		chainIds.push(createChainIdFromParent(chainIds[i], [ diffIds[i + 1] ]))
+	return chainIds
+
 # Function adapted to JavaScript from
 # https://github.com/docker/docker/blob/v1.10.3/layer/layer.go#L223-L226
 createChainIdFromParent = (parent, dgsts) ->
@@ -42,45 +49,105 @@ createChainIdFromParent = (parent, dgsts) ->
 
 	return createChainIdFromParent(dgst, dgsts[1..])
 
+getDiffIds = Promise.method (dkroot, driver, imageId) ->
+	[ hashType, hash ] = imageId.split(':')
+	fs.readFileAsync(path.join(dkroot, "image/#{driver}/imagedb/content", hashType, hash))
+	.then(JSON.parse)
+	.get('rootfs').get('diff_ids')
+
+getCacheId = Promise.method (dkroot, driver, layerId) ->
+	[ hashType, hash ] = layerId.split(':')
+	cacheIdPath = path.join(dkroot, "image/#{driver}/layerdb", hashType, hash, 'cache-id')
+	# Resolves with 'rootId'
+	fs.readFileAsync(cacheIdPath, encoding: 'utf8')
+
 # Gets an string `image` as input and returns a promise that
 # resolves to the absolute path of the root directory for that image
+#
+# Note: in aufs, the path corresponds to the directory for only
+# the specific layer's fs.
 Docker::imageRootDir = (image) ->
-	Promise.all [
+	Promise.join(
 		@infoAsync()
 		@versionAsync().get('Version')
 		@getImage(image).inspectAsync()
-	]
-	.spread (dockerInfo, dockerVersion, imageInfo) ->
-		dkroot = dockerInfo.DockerRootDir
+		(dockerInfo, dockerVersion, imageInfo) ->
+			dkroot = dockerInfo.DockerRootDir
 
-		imageId = imageInfo.Id
+			imageId = imageInfo.Id
 
-		Promise.try ->
-			if semver.lt(dockerVersion, '1.10.0')
-				return imageId
+			Promise.try ->
+				if semver.lt(dockerVersion, '1.10.0')
+					return imageId
 
-			[ hashType, hash ] = imageId.split(':')
+				getDiffIds(dkroot, dockerInfo.Driver, imageId)
+				.then (diffIds) ->
+					layerId = createChainId(diffIds)
+					getCacheId(dkroot, dockerInfo.Driver, layerId)
+			.then (destId) ->
+				switch dockerInfo.Driver
+					when 'btrfs'
+						path.join(dkroot, 'btrfs/subvolumes', destId)
+					when 'overlay'
+						imageInfo.GraphDriver.Data.RootDir
+					when 'vfs'
+						path.join(dkroot, 'vfs/dir', destId)
+					when 'aufs'
+						path.join(dkroot, 'aufs/diff', destId)
+					else
+						throw new Error("Unsupported driver: #{dockerInfo.Driver}/")
+	)
+# Same as imageRootDir, but provides the full mounted rootfs for AUFS,
+# and has a disposer to unmount.
+Docker::imageRootDirMounted = (image) ->
+	Promise.join(
+		@infoAsync()
+		@versionAsync().get('Version')
+		@getImage(image).inspectAsync()
+		(dockerInfo, dockerVersion, imageInfo) =>
+			driver = dockerInfo.Driver
+			dkroot = dockerInfo.DockerRootDir
+			imageId = imageInfo.Id
+			return @imageRootDir(image) if driver isnt 'aufs'
+			@aufsDiffPaths(image)
+			.then (layerDiffPaths) ->
+				branchesOption = 'br=' + layerDiffPaths.join('=ro:') + '=ro'
+				rootDir = path.join(dkroot, 'aufs/mnt', 'tmp' + imageId.split(':')[1])
+				fs.mkdirAsync(rootDir)
+				.then ->
+					execAsync("mount -t aufs -o 'noxino,ro,#{branchesOption}' none #{rootDir}")
+				.return(rootDir)
+				.disposer (rootDir) ->
+					execAsync("umount #{rootDir}")
+					.then ->
+						fs.rmdirAsync(rootDir)
+					.catch (err) ->
+						# We don't want to crash the node process if something failed here...
+						console.error('Failed to clean up after imageRootDirMounted', err, err.stack)
+						return
+	)
 
-			fs.readFileAsync(path.join(dkroot, "image/#{dockerInfo.Driver}/imagedb/content", hashType, hash))
-			.then(JSON.parse)
-			.then (metadata) ->
-				layerId = createChainId(metadata.rootfs.diff_ids)
-				[ hashType, hash ] = layerId.split(':')
-
-				cacheIdPath = path.join(dkroot, "image/#{dockerInfo.Driver}/layerdb", hashType, hash, 'cache-id')
-
-				# Resolves with 'rootId'
-				fs.readFileAsync(cacheIdPath, encoding: 'utf8')
-		.then (destId) ->
-			switch dockerInfo.Driver
-				when 'btrfs'
-					path.join(dkroot, 'btrfs/subvolumes', destId)
-				when 'overlay'
-					imageInfo.GraphDriver.Data.RootDir
-				when 'vfs'
-					path.join(dkroot, 'vfs/dir', destId)
-				else
-					throw new Error("Unsupported driver: #{dockerInfo.Driver}/")
+# Only for AUFS: get the diff paths for each layer in the image
+# Ordered from latest to parent.
+Docker::aufsDiffPaths = (image) ->
+	Promise.join(
+		@infoAsync()
+		@versionAsync().get('Version')
+		@getImage(image).inspectAsync()
+		(dockerInfo, dockerVersion, imageInfo) ->
+			driver = dockerInfo.Driver
+			throw new Error('aufsDiffPaths can only be used on aufs') if driver isnt 'aufs'
+			dkroot = dockerInfo.DockerRootDir
+			imageId = imageInfo.Id
+			getDiffIds(dkroot, driver, imageId)
+			.then (diffIds) ->
+				return diffIds if semver.lt(dockerVersion, '1.10.0')
+				Promise.map getAllChainIds(diffIds), (layerId) ->
+					getCacheId(dkroot, driver, layerId)
+			.map (layerId) ->
+				path.join(dkroot, 'aufs/diff', layerId)
+			.call('reverse')
+	)
 
 # Given an image configuration it constructs a valid tar archive in the same
 # way a `docker save` would have done that contains an empty filesystem image


### PR DESCRIPTION
imageRootDir now works for aufs, but shows only the last diff in the image.
To have fully compatible behavior, imageRootDirMounted should be used, so that
the full image rootfs gets mounted at the returned path. For other drivers,
behavior will be the same as imageRootDir (only it has to be used with Promise.using).

aufsDiffPaths allows getting the paths for each layer diff in an aufs-stored image.

These functions will be necessary to adapt https://github.com/resin-io/node-docker-delta to work on AUFS.