### PR TITLE
Fix mounting aufs when there's several layers and use random path for mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bluebird": "^3.4.1",
     "dockerode": "^2.2.10",
     "event-stream": "^3.3.3",
+    "randomstring": "^1.1.5",
     "semver": "^5.2.0",
     "tar-stream": "^1.5.2"
   },


### PR DESCRIPTION
Fixes #9 

mount limits the mount options to page size (usually 4096 bytes), so we do what docker does
to mount when layers don't fit in that: we mount with as much as we can fit and then
remount appending each remaining layer. We stick to 4096 instead of actually finding the page size
cause it's assured to work (4096 is the minimum in the arches we support), reduces complexity and
shouldn't generate much overhead (we don't care about a few extra remounts).

Based on https://github.com/docker/docker/blob/b937aa8e6968d805527d163e6f477d496ceb88d7/daemon/graphdriver/aufs/aufs.go#L595

We also introduce 8 random characters to the temporary path we use for the aufs mount, so that
several calls to this function can work independently.

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>