### PR TITLE
Support docker 17.03 by making the semver check more forgiving

### DIFF
--- a/lib/docker-toolbelt.coffee
+++ b/lib/docker-toolbelt.coffee
@@ -82,7 +82,7 @@ Docker::imageRootDir = (image) ->
 			imageId = imageInfo.Id
 
 			Promise.try ->
-				if semver.lt(dockerVersion, '1.10.0')
+				if semver.lt(dockerVersion, '1.10.0', true)
 					return imageId
 
 				getDiffIds(dkroot, dockerInfo.Driver, imageId)
@@ -173,7 +173,7 @@ Docker::aufsDiffPaths = (image) ->
 			imageId = imageInfo.Id
 			getDiffIds(dkroot, driver, imageId)
 			.then (diffIds) ->
-				return diffIds if semver.lt(dockerVersion, '1.10.0')
+				return diffIds if semver.lt(dockerVersion, '1.10.0', true)
 				Promise.map getAllChainIds(diffIds), (layerId) ->
 					getCacheId(dkroot, driver, layerId)
 			.map (layerId) ->


### PR DESCRIPTION
In docker 17.03, docker moved to a not-quite-semver-compatible versioning
scheme. We add a `true` third argument to the semver comparison to make it
more forgiving and properly compare 17.03.1-ce and the like as if they were semver.

Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>