### PR TITLE
Update versionist to v2.8.1 and remove unnecessary versionist.conf.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "devDependencies": {
     "coffee-script": "^1.10.0",
     "resin-lint": "^1.4.0",
-    "versionist": "^2.6.2"
+    "versionist": "^2.8.1"
   }
 }

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,1 +1,0 @@
-module.exports = require('versionist/versionist.conf');


### PR DESCRIPTION
Change-Type: patch
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>

(Some versions of versionist get confused with the legacy versionist.conf.js we had - so this fixes it)