### PR TITLE
Update resin-semver to support balenaOS version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dockerode": "^2.5.0",
     "event-stream": "^3.3.3",
     "randomstring": "^1.1.5",
-    "resin-semver": "^1.3.0",
+    "resin-semver": "^1.4.0",
     "tar-stream": "^1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)